### PR TITLE
Fix issue #4: Readme document need update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ west build -b $BOARD app
 
 where `$BOARD` is the target board.
 
+    36
+    37 ## Support for gd32e230 Board
+    38
+    39 This repository now supports the gd32e230 board. To build and run a sample
+    40 application for this board, follow these steps:
+    41
+    42 ### Building and Running for gd32e230
+    43
+    44 1. Build the application for the gd32e230 board:
+    45
+    46     ```shell
+    47     cd zephyr-boards
+    48     west build -b gd32e230 app
+    49     ```
+    50
+    51 2. Flash the application to the gd32e230 board:
+    52
+    53     ```shell
+    54     west flash
+    55     ```
+    56
+    57 3. Alternatively, you can run a sample application from the Zephyr samples:
+    58
+    59     ```shell
+    60     cd zephyr-boards
+    61     west build -b gd32e230 zephyr/samples/hello_world
+    62     west flash
+    63     ```
+    64
+
 You can use the `custom_plank` board found in this
 repository. Note that Zephyr sample boards may be used if an
 appropriate overlay is provided (see `app/boards`).


### PR DESCRIPTION
This pull request fixes #4.

The PR addresses the issue by updating the README.md file to include instructions specific to the gd32e230 board. The changes add a section titled "Support for gd32e230 Board" that provides step-by-step instructions for building and running a sample application for this board using the `west` command-line tool. The expected impact of these changes is that users will be able to easily find and follow the necessary steps to work with the gd32e230 board, thus resolving the issue of the outdated documentation.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌